### PR TITLE
Fix two issues related to CI/CD workflow and CCS installer download.

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.4
+        uses: actions/checkout@v6.0.2
         
       - name: Bump version and push tag
         id: tag_version
@@ -21,7 +21,7 @@ jobs:
           RELEASE_BRANCHES: main
 
       - name: Create Release
-        uses: ncipollo/release-action@v1.14.0
+        uses: ncipollo/release-action@v1.21.0
         with:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: Release ${{ steps.tag_version.outputs.new_tag }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -58,7 +58,7 @@ if [ "${MAJOR_VER}" -ge 20 ]; then
     chmod +x "ccs_setup_${VER}.run"
     "./ccs_setup_${VER}.run" --mode unattended --enable-components "${COMPONENTS}" --prefix /opt/ti
 else
-    wget --timeout=300 --tries=3 "${CCS_URL}${VER}/CCS${VER}_linux-x64.tar.gz"
+    wget --timeout=300 --tries=3 "${CCS_URL}${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/CCS${VER}_linux-x64.tar.gz"
     echo ">>> Extracting..."
     tar -zxf "CCS${VER}_linux-x64.tar.gz"
     chmod -R 755 "CCS${VER}_linux-x64"


### PR DESCRIPTION
## Summary

Fix two issues related to CI/CD workflow and CCS installer download.

## Changes

### `.github/workflows/update-version.yml`
- Bump `actions/checkout` from `v4.1.4` → `v6.0.2`
- Bump `ncipollo/release-action` from `v1.14.0` → `v1.21.0`

### `entrypoint.sh`
- Fix CCS v12 download URL: changed from 4-part version path (`${CCS_URL}${VER}/...`) to 3-part version path (`${CCS_URL}${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/...`)
  - Before: `"${CCS_URL}${VER}/CCS${VER}_linux-x64.tar.gz"`
  - After: `"${CCS_URL}${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/CCS${VER}_linux-x64.tar.gz"`

## Motivation

- Workflow actions updated to Node.js 24 compatible versions to prevent deprecation warnings/failures in GitHub Actions.
- CCS v12 uses a 3-part version directory structure in its download URL (unlike v11 and below), causing the wget to fail with the old 4-part path.

## Related Issues

Closes #4