### PR TITLE
🐛 fix project import path, add auto-import option, document SLF4J warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,18 @@ When installing [Code Composer Studio](https://www.ti.com/tool/CCSTUDIO), you ca
 | PF_C64MC          | C64x multicore DSP                                                           |
 | PF_DIGITAL_POWER  | UCD Digital Power Controllers                                                |
 
+### auto-import (optional)
+
+When set to `true`, uses the `-ccs.autoImport` flag to automatically discover and import **all** CCS projects found under `project-path`. This is useful when your project has shared dependency projects in the same workspace.
+
+```yaml
+with:
+    project-path: 'Workspace'   # root directory containing all projects
+    auto-import: 'true'
+```
+
+Default Value: `false` (imports only the single project at `project-path`).
+
 Multiple product families can be installed by separating their names with a comma in the `components` input:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -17,6 +17,20 @@ Each run of this action downloads and installs Code Composer Studio from scratch
 
 Supported CCS versions: **v7.x – v20.x**
 
+## Known Warnings
+
+### SLF4J
+
+The following lines may appear in the action log during project import or build:
+
+```text
+SLF4J: Failed to load class 'org.slf4j.impl.StaticLoggerBinder'.
+SLF4J: Defaulting to no-operation (NOP) logger implementation
+SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
+```
+
+This is a harmless warning from Eclipse's internal logging framework. It does not affect the build result and can be safely ignored.
+
 ## Usage
 
 To use this action in your workflow, add the following steps to your `.github/workflows` YAML file:

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,10 @@ inputs:
         description: 'Components to install (e.g., PF_C28)'
         required: false
         default: 'PF_C28'
+    auto-import:
+        description: 'Automatically import all projects found under project-path (useful for workspaces with shared dependencies)'
+        required: false
+        default: 'false'
 
 runs:
     using: 'docker'
@@ -45,3 +49,4 @@ runs:
         - ${{ inputs.project-path }}
         - ${{ inputs.project-name }}
         - ${{ inputs.build-config }}
+        - ${{ inputs.auto-import }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -145,21 +145,25 @@ echo ""
 echo "=== CCS ${VER} is ready. ==="
 echo ""
 
+PROJECT_PATH="/github/workspace/$1"
+PROJECT_NAME="$2"
+BUILD_CONFIG="$3"
+
 echo "=== Project Build ==="
-echo "Project Path  : $1"
-echo "Project Name  : $2"
-echo "Configuration : $3"
+echo "Project Path  : ${PROJECT_PATH}"
+echo "Project Name  : ${PROJECT_NAME}"
+echo "Configuration : ${BUILD_CONFIG}"
 echo ""
 
 echo ">>> Importing project..."
 if [ "${MAJOR_VER}" -ge 20 ]; then
     "${CCS_ECLIPSE_DIR}/ccs-server-cli.sh" -noSplash -workspace /tmp/workspace \
         -application com.ti.ccs.apps.importProject \
-        -ccs.location "$1"
+        -ccs.location "${PROJECT_PATH}"
 else
     "${CCS_ECLIPSE_DIR}/eclipse" -noSplash -data /tmp/workspace \
         -application com.ti.ccstudio.apps.projectImport \
-        -ccs.location "$1"
+        -ccs.location "${PROJECT_PATH}"
 fi
 
 echo ">>> Building project..."
@@ -169,20 +173,20 @@ BUILD_FAILED=0
 if [ "${MAJOR_VER}" -ge 20 ]; then
     "${CCS_ECLIPSE_DIR}/ccs-server-cli.sh" -noSplash -workspace /tmp/workspace \
         -application com.ti.ccs.apps.buildProject \
-        -ccs.projects "$2" \
-        -ccs.configuration "$3" \
+        -ccs.projects "${PROJECT_NAME}" \
+        -ccs.configuration "${BUILD_CONFIG}" \
         -ccs.listErrors 2>&1 | tee "${BUILD_LOG}" || BUILD_FAILED=1
 elif [ "${MAJOR_VER}" -ge 11 ]; then
     "${CCS_ECLIPSE_DIR}/eclipse" -noSplash -data /tmp/workspace \
         -application com.ti.ccstudio.apps.projectBuild \
-        -ccs.projects "$2" \
-        -ccs.configuration "$3" \
+        -ccs.projects "${PROJECT_NAME}" \
+        -ccs.configuration "${BUILD_CONFIG}" \
         -ccs.listErrors 2>&1 | tee "${BUILD_LOG}" || BUILD_FAILED=1
 else
     "${CCS_ECLIPSE_DIR}/eclipse" -noSplash -data /tmp/workspace \
         -application com.ti.ccstudio.apps.projectBuild \
-        -ccs.projects "$2" \
-        -ccs.configuration "$3" \
+        -ccs.projects "${PROJECT_NAME}" \
+        -ccs.configuration "${BUILD_CONFIG}" \
         2>&1 | tee "${BUILD_LOG}" || BUILD_FAILED=1
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -148,22 +148,30 @@ echo ""
 PROJECT_PATH="/github/workspace/$1"
 PROJECT_NAME="$2"
 BUILD_CONFIG="$3"
+AUTO_IMPORT="${4:-false}"
 
 echo "=== Project Build ==="
 echo "Project Path  : ${PROJECT_PATH}"
 echo "Project Name  : ${PROJECT_NAME}"
 echo "Configuration : ${BUILD_CONFIG}"
+echo "Auto Import   : ${AUTO_IMPORT}"
 echo ""
 
 echo ">>> Importing project..."
+if [ "${AUTO_IMPORT}" = "true" ]; then
+    IMPORT_FLAGS="-ccs.autoImport -ccs.location ${PROJECT_PATH}"
+else
+    IMPORT_FLAGS="-ccs.location ${PROJECT_PATH}"
+fi
+
 if [ "${MAJOR_VER}" -ge 20 ]; then
     "${CCS_ECLIPSE_DIR}/ccs-server-cli.sh" -noSplash -workspace /tmp/workspace \
         -application com.ti.ccs.apps.importProject \
-        -ccs.location "${PROJECT_PATH}"
+        ${IMPORT_FLAGS}
 else
     "${CCS_ECLIPSE_DIR}/eclipse" -noSplash -data /tmp/workspace \
         -application com.ti.ccstudio.apps.projectImport \
-        -ccs.location "${PROJECT_PATH}"
+        ${IMPORT_FLAGS}
 fi
 
 echo ">>> Building project..."


### PR DESCRIPTION
## Summary

- **🐛 fix project import path** — `project-path` was resolved relative to `/home` after the cleanup `cd /home` step, causing project import to fail. Now automatically prefixed with `/github/workspace/` to correctly resolve against the Docker workspace root. (Closes #1)

- **📝 document SLF4J warning** — Added a note to the README clarifying that the SLF4J log lines from Eclipse's internal logging framework are harmless and can be safely ignored. (Relates to #1)

- **✨ add auto-import option** — New `auto-import` input that passes the `-ccs.autoImport` flag to the CCS import step, enabling automatic discovery and import of all projects under `project-path`. Useful for workspaces with shared dependency projects. (Closes #2)