### PR TITLE
✨ Integrate CCS installation logic from docker-ccstudio-ide

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,16 @@
 # This will be set automatically from the git tag during build
 ARG CCS_VERSION=latest
 
-# Base Image with specific CCS version pre-installed
+# Base Image with CCS installer pre-extracted
 FROM uoohyo/ccstudio-ide:${CCS_VERSION}
 
 # Metadata
 LABEL org.opencontainers.image.source="https://github.com/uoohyo/action-ccstudio-ide"
 LABEL org.opencontainers.image.description="Build with Code Composer Studio ${CCS_VERSION}"
 LABEL org.opencontainers.image.licenses="MIT"
+
+# Pass CCS version to entrypoint
+ENV CCS_VERSION=${CCS_VERSION}
 
 # Copy entrypoint script
 COPY --chmod=755 entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The [action-ccstudio-ide](https://github.com/uoohyo/action-ccstudio-ide) GitHub 
 
 ## Overview
 
-This action uses **pre-built Docker images** from [docker-ccstudio-ide](https://github.com/uoohyo/docker-ccstudio-ide) with Code Composer Studio already installed. Build time is typically **1–3 minutes** for pulling the image and building your project.
+This action uses Docker images from [docker-ccstudio-ide](https://github.com/uoohyo/docker-ccstudio-ide) that contain the CCS installer pre-extracted. The action automatically installs CCS and builds your project. Typical workflow time: **4–7 minutes** (3–5 min installation + 1–2 min build).
 
 > **Note:** This action runs inside a Docker container and requires a **Linux** runner (e.g. `ubuntu-22.04`).
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -51,148 +51,129 @@ else
     CCS_ECLIPSE_DIR="/opt/ti/ccsv${MAJOR_VER}/eclipse"
 fi
 
-# Check if CCS is already installed
-CCS_INSTALLED=false
+# Install CCS
+echo "=== CCS Installation ==="
+echo "Version    : ${VER}"
+echo "Components : ${COMPONENTS}"
+echo ""
+
+# Docker-specific stubs for installer compatibility
 if [ "${MAJOR_VER}" -ge 20 ]; then
-    # v20+: Check for ccs-server-cli.sh
-    if [ -x "${CCS_ECLIPSE_DIR}/ccs-server-cli.sh" ]; then
-        CCS_INSTALLED=true
-    fi
-else
-    # v7-19: Check for eclipse binary
-    if [ -x "${CCS_ECLIPSE_DIR}/eclipse" ]; then
-        CCS_INSTALLED=true
-    fi
+    # v20+: BlackHawk installer calls udev/kernel commands
+    ln -sf /bin/true /usr/local/bin/udevadm 2>/dev/null || true
+    ln -sf /bin/true /sbin/start_udev 2>/dev/null || true
+    ln -sf /bin/true /sbin/udevd 2>/dev/null || true
+    ln -sf /bin/true /sbin/modprobe 2>/dev/null || true
+    ln -sf /bin/true /sbin/insmod 2>/dev/null || true
+    ln -sf /bin/true /sbin/rmmod 2>/dev/null || true
+    mkdir -p /etc/udev/rules.d /run/udev /lib/modules 2>/dev/null || true
 fi
 
-# Install CCS if not already installed
-if [ "$CCS_INSTALLED" = false ]; then
-    echo "=== CCS Installation ==="
-    echo "Version    : ${VER}"
-    echo "Components : ${COMPONENTS}"
+# Start Xvfb for v7-v8 BitRock installers (GUI framework support)
+XVFB_PID=""
+if [ "${MAJOR_VER}" -le 8 ]; then
+    echo ">>> Starting virtual display for v${MAJOR_VER} BitRock installer..."
+    export DISPLAY=:99
+    export GDK_BACKEND=x11
+    export GTK_MODULES=""
+    export NO_AT_BRIDGE=1
+    export LIBGL_ALWAYS_INDIRECT=1
+    Xvfb :99 -ac -screen 0 1024x768x24 -nolisten tcp > /dev/null 2>&1 &
+    XVFB_PID=$!
+    sleep 2
+    echo ">>> Virtual display ready (DISPLAY=${DISPLAY}, PID=${XVFB_PID})"
+fi
+
+# Cleanup function for Xvfb
+cleanup_xvfb() {
+    if [ -n "$XVFB_PID" ]; then
+        echo ">>> Stopping virtual display..."
+        kill $XVFB_PID 2>/dev/null || true
+        wait $XVFB_PID 2>/dev/null || true
+    fi
+}
+trap cleanup_xvfb EXIT
+
+# Create temporary directory for installation
+INSTALL_LOG="/tmp/ccs_install.log"
+mkdir -p /ccs_install
+cd /ccs_install
+
+_show_install_logs() {
     echo ""
+    echo "=== Installer Output ==="
+    cat "${INSTALL_LOG}" 2>/dev/null || echo "(no output captured)"
+    echo ""
+    echo "=== TI Installer Logs ==="
+    find /root/.ti /tmp /opt/ti -name "*.log" 2>/dev/null | while read -r f; do
+        echo "--- ${f} ---"
+        cat "${f}"
+    done
+    echo "========================"
+}
 
-    # Docker-specific stubs for installer compatibility
-    if [ "${MAJOR_VER}" -ge 20 ]; then
-        # v20+: BlackHawk installer calls udev/kernel commands
-        ln -sf /bin/true /usr/local/bin/udevadm 2>/dev/null || true
-        ln -sf /bin/true /sbin/start_udev 2>/dev/null || true
-        ln -sf /bin/true /sbin/udevd 2>/dev/null || true
-        ln -sf /bin/true /sbin/modprobe 2>/dev/null || true
-        ln -sf /bin/true /sbin/insmod 2>/dev/null || true
-        ln -sf /bin/true /sbin/rmmod 2>/dev/null || true
-        mkdir -p /etc/udev/rules.d /run/udev /lib/modules 2>/dev/null || true
-    fi
+# Install CCS from pre-downloaded and extracted files
+echo ">>> Using pre-downloaded CCS ${VER} installer..."
+if [ "${MAJOR_VER}" -ge 20 ]; then
+    echo ">>> Installing CCS ${VER} (this may take a few minutes)..."
+    cd "/opt/ccs-installer/CCS_${VER}_linux"
+    chmod +x "ccs_setup_${VER}.run"
+    "./ccs_setup_${VER}.run" --mode unattended --enable-components "${COMPONENTS}" --prefix /opt/ti 2>&1 | tee "${INSTALL_LOG}"
+else
+    # Driver install scripts fix for v7-v19
+    mkdir -p /etc/init.d /etc/udev/rules.d /root/.ti
+    printf '#!/bin/sh\nexit 0\n' > /etc/init.d/udev && chmod 755 /etc/init.d/udev
+    ln -sf /bin/true /usr/local/bin/udevadm 2>/dev/null || true
+    ln -sf /bin/true /usr/local/bin/systemctl 2>/dev/null || true
 
-    # Start Xvfb for v7-v8 BitRock installers (GUI framework support)
-    XVFB_PID=""
-    if [ "${MAJOR_VER}" -le 8 ]; then
-        echo ">>> Starting virtual display for v${MAJOR_VER} BitRock installer..."
-        export DISPLAY=:99
-        export GDK_BACKEND=x11
-        export GTK_MODULES=""
-        export NO_AT_BRIDGE=1
-        export LIBGL_ALWAYS_INDIRECT=1
-        Xvfb :99 -ac -screen 0 1024x768x24 -nolisten tcp > /dev/null 2>&1 &
-        XVFB_PID=$!
-        sleep 2
-        echo ">>> Virtual display ready (DISPLAY=${DISPLAY}, PID=${XVFB_PID})"
-    fi
-
-    # Cleanup function for Xvfb
-    cleanup_xvfb() {
-        if [ -n "$XVFB_PID" ]; then
-            echo ">>> Stopping virtual display..."
-            kill $XVFB_PID 2>/dev/null || true
-            wait $XVFB_PID 2>/dev/null || true
-        fi
-    }
-    trap cleanup_xvfb EXIT
-
-    # Create temporary directory for installation
-    INSTALL_LOG="/tmp/ccs_install.log"
-    mkdir -p /ccs_install
-    cd /ccs_install
-
-    _show_install_logs() {
-        echo ""
-        echo "=== Installer Output ==="
-        cat "${INSTALL_LOG}" 2>/dev/null || echo "(no output captured)"
-        echo ""
-        echo "=== TI Installer Logs ==="
-        find /root/.ti /tmp /opt/ti -name "*.log" 2>/dev/null | while read -r f; do
-            echo "--- ${f} ---"
-            cat "${f}"
-        done
-        echo "========================"
-    }
-
-    # Install CCS from pre-downloaded and extracted files
-    echo ">>> Using pre-downloaded CCS ${VER} installer..."
-    if [ "${MAJOR_VER}" -ge 20 ]; then
-        echo ">>> Installing CCS ${VER} (this may take a few minutes)..."
-        cd "/opt/ccs-installer/CCS_${VER}_linux"
-        chmod +x "ccs_setup_${VER}.run"
-        "./ccs_setup_${VER}.run" --mode unattended --enable-components "${COMPONENTS}" --prefix /opt/ti 2>&1 | tee "${INSTALL_LOG}"
+    echo ">>> Installing CCS ${VER} (this may take a few minutes)..."
+    if [ "${MAJOR_VER}" -ge 10 ]; then
+        # v10+: new installer (.run, supports --enable-components)
+        "/opt/ccs-installer/CCS${VER}_linux-x64/ccs_setup_${VER}.run" \
+            --mode unattended --enable-components "${COMPONENTS}" --prefix /opt/ti \
+            --install-BlackHawk false --install-Segger false 2>&1 | tee "${INSTALL_LOG}"
     else
-        # Driver install scripts fix for v7-v19
-        mkdir -p /etc/init.d /etc/udev/rules.d /root/.ti
-        printf '#!/bin/sh\nexit 0\n' > /etc/init.d/udev && chmod 755 /etc/init.d/udev
-        ln -sf /bin/true /usr/local/bin/udevadm 2>/dev/null || true
-        ln -sf /bin/true /usr/local/bin/systemctl 2>/dev/null || true
-
-        echo ">>> Installing CCS ${VER} (this may take a few minutes)..."
-        if [ "${MAJOR_VER}" -ge 10 ]; then
-            # v10+: new installer (.run, supports --enable-components)
-            "/opt/ccs-installer/CCS${VER}_linux-x64/ccs_setup_${VER}.run" \
-                --mode unattended --enable-components "${COMPONENTS}" --prefix /opt/ti \
+        # v7-v9: old BitRock installer
+        echo ">>> Note: --enable-components is not supported for CCS v9 and below. Installing all components."
+        INSTALLER_BIN=$(find "/opt/ccs-installer/CCS${VER}_linux-x64" -maxdepth 1 \( -name "*.bin" -o -name "*.run" \) | sort | head -1)
+        if [ "${MAJOR_VER}" -le 8 ]; then
+            export JAVA_TOOL_OPTIONS=-Xss1280k
+            DISPLAY=:99 "${INSTALLER_BIN}" \
+                --mode unattended --prefix /opt/ti \
                 --install-BlackHawk false --install-Segger false 2>&1 | tee "${INSTALL_LOG}"
         else
-            # v7-v9: old BitRock installer
-            echo ">>> Note: --enable-components is not supported for CCS v9 and below. Installing all components."
-            INSTALLER_BIN=$(find "/opt/ccs-installer/CCS${VER}_linux-x64" -maxdepth 1 \( -name "*.bin" -o -name "*.run" \) | sort | head -1)
-            if [ "${MAJOR_VER}" -le 8 ]; then
-                export JAVA_TOOL_OPTIONS=-Xss1280k
-                DISPLAY=:99 "${INSTALLER_BIN}" \
-                    --mode unattended --prefix /opt/ti \
-                    --install-BlackHawk false --install-Segger false 2>&1 | tee "${INSTALL_LOG}"
-            else
-                "${INSTALLER_BIN}" \
-                    --mode unattended --prefix /opt/ti \
-                    --install-BlackHawk false --install-Segger false 2>&1 | tee "${INSTALL_LOG}"
-            fi
+            "${INSTALLER_BIN}" \
+                --mode unattended --prefix /opt/ti \
+                --install-BlackHawk false --install-Segger false 2>&1 | tee "${INSTALL_LOG}"
         fi
     fi
-
-    # Verify Installation
-    echo ">>> Verifying CCS installation..."
-    if [ "${MAJOR_VER}" -ge 20 ]; then
-        if ! test -x "${CCS_ECLIPSE_DIR}/ccs-server-cli.sh"; then
-            echo "[ERROR] CCS installation failed: ccs-server-cli.sh not found"
-            _show_install_logs
-            exit 1
-        fi
-    else
-        if ! test -x "${CCS_ECLIPSE_DIR}/eclipse"; then
-            echo "[ERROR] CCS installation failed: eclipse not found"
-            _show_install_logs
-            exit 1
-        fi
-    fi
-    echo ">>> CCS ${VER} installation complete."
-
-    # Cleanup
-    echo ">>> Cleaning up installer files..."
-    cd /home
-    rm -rf /opt/ccs-installer /ccs_install
-
-    echo ""
-    echo "=== CCS ${VER} is ready. ==="
-    echo ""
-else
-    echo "=== CCS ${VER} already installed ==="
-    echo ""
 fi
+
+# Verify Installation
+echo ">>> Verifying CCS installation..."
+if [ "${MAJOR_VER}" -ge 20 ]; then
+    if ! test -x "${CCS_ECLIPSE_DIR}/ccs-server-cli.sh"; then
+        echo "[ERROR] CCS installation failed: ccs-server-cli.sh not found"
+        _show_install_logs
+        exit 1
+    fi
+else
+    if ! test -x "${CCS_ECLIPSE_DIR}/eclipse"; then
+        echo "[ERROR] CCS installation failed: eclipse not found"
+        _show_install_logs
+        exit 1
+    fi
+fi
+echo ">>> CCS ${VER} installation complete."
+
+# Cleanup
+echo ">>> Cleaning up installer files..."
+cd /home
+rm -rf /opt/ccs-installer /ccs_install
+
+echo ""
+echo "=== CCS ${VER} is ready. ==="
+echo ""
 
 # Export CCS to PATH
 export PATH="${CCS_ECLIPSE_DIR}:${PATH}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,26 +19,182 @@ $$ |  $$ |\$$$$$$$\   \$$$$  |$$ |\$$$$$$  |$$ |  $$ |      \$$$$$$  |\$$$$$$  |
 
 EOF
 
-# Detect CCS installation path
-# docker-ccstudio-ide pre-installs CCS at a fixed location
-# v20+: /opt/ti/ccs/eclipse (Theia-based)
-# v9-19: /opt/ti/ccs/eclipse (Eclipse-based)
-# v7-8: /opt/ti/ccsv<MAJOR>/eclipse
-if [ -d "/opt/ti/ccs/eclipse" ]; then
-    CCS_ECLIPSE_DIR="/opt/ti/ccs/eclipse"
-elif [ -d "/opt/ti/ccsv8/eclipse" ]; then
-    CCS_ECLIPSE_DIR="/opt/ti/ccsv8/eclipse"
-elif [ -d "/opt/ti/ccsv7/eclipse" ]; then
-    CCS_ECLIPSE_DIR="/opt/ti/ccsv7/eclipse"
-else
-    echo "[ERROR] CCS installation not found"
-    echo "Expected locations:"
-    echo "  - /opt/ti/ccs/eclipse (v9+)"
-    echo "  - /opt/ti/ccsv8/eclipse (v8)"
-    echo "  - /opt/ti/ccsv7/eclipse (v7)"
-    exit 1
+# Parse CCS version from environment variable
+# CCS_VERSION format: MAJOR.MINOR.PATCH.BUILD (e.g., 20.5.0.00028)
+if [ -z "${CCS_VERSION}" ] || [ "${CCS_VERSION}" = "latest" ]; then
+    # Try to detect from pre-extracted installer directory
+    if [ -d "/opt/ccs-installer" ]; then
+        INSTALLER_DIR=$(find /opt/ccs-installer -maxdepth 1 -type d -name "CCS*" | head -1)
+        if [ -n "$INSTALLER_DIR" ]; then
+            CCS_VERSION=$(basename "$INSTALLER_DIR" | sed 's/^CCS_\?//' | sed 's/_linux.*//')
+        fi
+    fi
+
+    # If still not found, fail
+    if [ -z "${CCS_VERSION}" ] || [ "${CCS_VERSION}" = "latest" ]; then
+        echo "[ERROR] CCS_VERSION not set and could not be detected"
+        exit 1
+    fi
 fi
 
+VER="${CCS_VERSION}"
+MAJOR_VER=$(echo "$VER" | cut -d. -f1)
+MINOR_VER=$(echo "$VER" | cut -d. -f2)
+PATCH_VER=$(echo "$VER" | cut -d. -f3)
+BUILD_VER=$(echo "$VER" | cut -d. -f4)
+
+# Determine CCS installation path
+# v9+: installs to /opt/ti/ccs/eclipse; v8-: installs to /opt/ti/ccsv<MAJOR>/eclipse
+if [ "${MAJOR_VER}" -ge 9 ]; then
+    CCS_ECLIPSE_DIR="/opt/ti/ccs/eclipse"
+else
+    CCS_ECLIPSE_DIR="/opt/ti/ccsv${MAJOR_VER}/eclipse"
+fi
+
+# Check if CCS is already installed
+CCS_INSTALLED=false
+if [ "${MAJOR_VER}" -ge 20 ]; then
+    # v20+: Check for ccs-server-cli.sh
+    if [ -x "${CCS_ECLIPSE_DIR}/ccs-server-cli.sh" ]; then
+        CCS_INSTALLED=true
+    fi
+else
+    # v7-19: Check for eclipse binary
+    if [ -x "${CCS_ECLIPSE_DIR}/eclipse" ]; then
+        CCS_INSTALLED=true
+    fi
+fi
+
+# Install CCS if not already installed
+if [ "$CCS_INSTALLED" = false ]; then
+    echo "=== CCS Installation ==="
+    echo "Version    : ${VER}"
+    echo "Components : ${COMPONENTS}"
+    echo ""
+
+    # Docker-specific stubs for installer compatibility
+    if [ "${MAJOR_VER}" -ge 20 ]; then
+        # v20+: BlackHawk installer calls udev/kernel commands
+        ln -sf /bin/true /usr/local/bin/udevadm 2>/dev/null || true
+        ln -sf /bin/true /sbin/start_udev 2>/dev/null || true
+        ln -sf /bin/true /sbin/udevd 2>/dev/null || true
+        ln -sf /bin/true /sbin/modprobe 2>/dev/null || true
+        ln -sf /bin/true /sbin/insmod 2>/dev/null || true
+        ln -sf /bin/true /sbin/rmmod 2>/dev/null || true
+        mkdir -p /etc/udev/rules.d /run/udev /lib/modules 2>/dev/null || true
+    fi
+
+    # Start Xvfb for v7-v8 BitRock installers (GUI framework support)
+    XVFB_PID=""
+    if [ "${MAJOR_VER}" -le 8 ]; then
+        echo ">>> Starting virtual display for v${MAJOR_VER} BitRock installer..."
+        export DISPLAY=:99
+        export GDK_BACKEND=x11
+        export GTK_MODULES=""
+        export NO_AT_BRIDGE=1
+        export LIBGL_ALWAYS_INDIRECT=1
+        Xvfb :99 -ac -screen 0 1024x768x24 -nolisten tcp > /dev/null 2>&1 &
+        XVFB_PID=$!
+        sleep 2
+        echo ">>> Virtual display ready (DISPLAY=${DISPLAY}, PID=${XVFB_PID})"
+    fi
+
+    # Cleanup function for Xvfb
+    cleanup_xvfb() {
+        if [ -n "$XVFB_PID" ]; then
+            echo ">>> Stopping virtual display..."
+            kill $XVFB_PID 2>/dev/null || true
+            wait $XVFB_PID 2>/dev/null || true
+        fi
+    }
+    trap cleanup_xvfb EXIT
+
+    # Create temporary directory for installation
+    INSTALL_LOG="/tmp/ccs_install.log"
+    mkdir -p /ccs_install
+    cd /ccs_install
+
+    _show_install_logs() {
+        echo ""
+        echo "=== Installer Output ==="
+        cat "${INSTALL_LOG}" 2>/dev/null || echo "(no output captured)"
+        echo ""
+        echo "=== TI Installer Logs ==="
+        find /root/.ti /tmp /opt/ti -name "*.log" 2>/dev/null | while read -r f; do
+            echo "--- ${f} ---"
+            cat "${f}"
+        done
+        echo "========================"
+    }
+
+    # Install CCS from pre-downloaded and extracted files
+    echo ">>> Using pre-downloaded CCS ${VER} installer..."
+    if [ "${MAJOR_VER}" -ge 20 ]; then
+        echo ">>> Installing CCS ${VER} (this may take a few minutes)..."
+        cd "/opt/ccs-installer/CCS_${VER}_linux"
+        chmod +x "ccs_setup_${VER}.run"
+        "./ccs_setup_${VER}.run" --mode unattended --enable-components "${COMPONENTS}" --prefix /opt/ti 2>&1 | tee "${INSTALL_LOG}"
+    else
+        # Driver install scripts fix for v7-v19
+        mkdir -p /etc/init.d /etc/udev/rules.d /root/.ti
+        printf '#!/bin/sh\nexit 0\n' > /etc/init.d/udev && chmod 755 /etc/init.d/udev
+        ln -sf /bin/true /usr/local/bin/udevadm 2>/dev/null || true
+        ln -sf /bin/true /usr/local/bin/systemctl 2>/dev/null || true
+
+        echo ">>> Installing CCS ${VER} (this may take a few minutes)..."
+        if [ "${MAJOR_VER}" -ge 10 ]; then
+            # v10+: new installer (.run, supports --enable-components)
+            "/opt/ccs-installer/CCS${VER}_linux-x64/ccs_setup_${VER}.run" \
+                --mode unattended --enable-components "${COMPONENTS}" --prefix /opt/ti \
+                --install-BlackHawk false --install-Segger false 2>&1 | tee "${INSTALL_LOG}"
+        else
+            # v7-v9: old BitRock installer
+            echo ">>> Note: --enable-components is not supported for CCS v9 and below. Installing all components."
+            INSTALLER_BIN=$(find "/opt/ccs-installer/CCS${VER}_linux-x64" -maxdepth 1 \( -name "*.bin" -o -name "*.run" \) | sort | head -1)
+            if [ "${MAJOR_VER}" -le 8 ]; then
+                export JAVA_TOOL_OPTIONS=-Xss1280k
+                DISPLAY=:99 "${INSTALLER_BIN}" \
+                    --mode unattended --prefix /opt/ti \
+                    --install-BlackHawk false --install-Segger false 2>&1 | tee "${INSTALL_LOG}"
+            else
+                "${INSTALLER_BIN}" \
+                    --mode unattended --prefix /opt/ti \
+                    --install-BlackHawk false --install-Segger false 2>&1 | tee "${INSTALL_LOG}"
+            fi
+        fi
+    fi
+
+    # Verify Installation
+    echo ">>> Verifying CCS installation..."
+    if [ "${MAJOR_VER}" -ge 20 ]; then
+        if ! test -x "${CCS_ECLIPSE_DIR}/ccs-server-cli.sh"; then
+            echo "[ERROR] CCS installation failed: ccs-server-cli.sh not found"
+            _show_install_logs
+            exit 1
+        fi
+    else
+        if ! test -x "${CCS_ECLIPSE_DIR}/eclipse"; then
+            echo "[ERROR] CCS installation failed: eclipse not found"
+            _show_install_logs
+            exit 1
+        fi
+    fi
+    echo ">>> CCS ${VER} installation complete."
+
+    # Cleanup
+    echo ">>> Cleaning up installer files..."
+    cd /home
+    rm -rf /opt/ccs-installer /ccs_install
+
+    echo ""
+    echo "=== CCS ${VER} is ready. ==="
+    echo ""
+else
+    echo "=== CCS ${VER} already installed ==="
+    echo ""
+fi
+
+# Export CCS to PATH
 export PATH="${CCS_ECLIPSE_DIR}:${PATH}"
 
 # Determine CCS version for logging
@@ -56,7 +212,7 @@ echo "Type         : ${CCS_TYPE}"
 echo "Components   : ${COMPONENTS}"
 echo ""
 
-# Parse arguments
+# Parse arguments for project build
 PROJECT_PATH="/github/workspace/$1"
 PROJECT_NAME="$2"
 BUILD_CONFIG="$3"
@@ -118,7 +274,6 @@ else
 fi
 
 # Check build result
-# CCS may return exit code 0 even on build failure — also check output
 if [ "${BUILD_FAILED}" -ne 0 ] || grep -qE "[1-9][0-9]* out of .* projects have errors" "${BUILD_LOG}"; then
     rm -f "${BUILD_LOG}"
     echo "[ERROR] Build failed."


### PR DESCRIPTION
## Summary

Integrates CCS installation logic from [docker-ccstudio-ide](https://github.com/uoohyo/docker-ccstudio-ide) into action-ccstudio-ide to support runtime CCS installation.

## Changes

### ✨ Features
- **Integrate CCS installation logic** from docker-ccstudio-ide
  - Auto-detect and parse CCS version (MAJOR.MINOR.PATCH.BUILD)
  - Support all CCS versions (v7-v20+) with version-specific installation
  - Include Xvfb setup for v7-v8 BitRock installers
  - Add udev stubs for v20+ BlackHawk installer compatibility
  - Clean up installer files after installation

### ♻️ Refactoring
- Remove unnecessary CCS installation check logic
  - GitHub Actions always starts fresh containers
  - CCS is never pre-installed in runtime environment
  - Simplified code by removing dead code paths

### 📝 Documentation
- Update README to reflect runtime CCS installation
  - Clarify that CCS installer is pre-extracted, not pre-installed
  - Update workflow time estimate: **4-7 minutes** (3-5 min install + 1-2 min build)
  - Remove misleading pre-built language

## Modified Files
- `Dockerfile` - Add CCS_VERSION environment variable
- `entrypoint.sh` - Integrate installation logic (+159 lines, -20 lines)
- `README.md` - Update Overview section

## Architecture

**Before:**
```
docker-ccstudio-ide (pre-built with CCS) 
  → action-ccstudio-ide (use installed CCS)
```

**After:**
```
docker-ccstudio-ide (installer pre-extracted)
  → action-ccstudio-ide (install CCS at runtime + build project)
```

## Test Plan
- [x] CCS installation logic tested in docker-ccstudio-ide
- [x] All CCS versions (v7-v20+) supported
- [ ] GitHub Actions workflow will validate on merge

---

**Closes:** N/A (Architecture improvement)
**Related:** [docker-ccstudio-ide](https://github.com/uoohyo/docker-ccstudio-ide)