### PR TITLE
🐛 Fix workspace path mismatch (Issue #13)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ nul
 .metadata/
 .history/
 
+# CCS workspace metadata (created during builds)
+.theia/
+RemoteSystemsTempFiles/
+
 # macOS 관련 파일
 .DS_Store
 .DS_Store?

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -210,6 +210,11 @@ PROJECT_NAME="$2"
 BUILD_CONFIG="$3"
 AUTO_IMPORT="${4:-false}"
 
+# Define CCS workspace directory
+# Use /github/workspace for CCS metadata to ensure build outputs are accessible
+# Fixes issue #13: Build output files were inaccessible when using ${CCS_WORKSPACE}
+CCS_WORKSPACE="/github/workspace"
+
 echo "=== Project Build ==="
 echo "Project Path  : ${PROJECT_PATH}"
 echo "Project Name  : ${PROJECT_NAME}"
@@ -227,12 +232,12 @@ fi
 
 if [ -x "${CCS_ECLIPSE_DIR}/ccs-server-cli.sh" ]; then
     # v20+ (Theia-based)
-    "${CCS_ECLIPSE_DIR}/ccs-server-cli.sh" -noSplash -workspace /tmp/workspace \
+    "${CCS_ECLIPSE_DIR}/ccs-server-cli.sh" -noSplash -workspace ${CCS_WORKSPACE} \
         -application com.ti.ccs.apps.importProject \
         "${IMPORT_FLAGS[@]}"
 else
     # v7-19 (Eclipse-based)
-    "${CCS_ECLIPSE_DIR}/eclipse" -noSplash -data /tmp/workspace \
+    "${CCS_ECLIPSE_DIR}/eclipse" -noSplash -data ${CCS_WORKSPACE} \
         -application com.ti.ccstudio.apps.projectImport \
         "${IMPORT_FLAGS[@]}"
 fi
@@ -244,21 +249,21 @@ BUILD_FAILED=0
 
 if [ -x "${CCS_ECLIPSE_DIR}/ccs-server-cli.sh" ]; then
     # v20+ (Theia-based)
-    "${CCS_ECLIPSE_DIR}/ccs-server-cli.sh" -noSplash -workspace /tmp/workspace \
+    "${CCS_ECLIPSE_DIR}/ccs-server-cli.sh" -noSplash -workspace ${CCS_WORKSPACE} \
         -application com.ti.ccs.apps.buildProject \
         -ccs.projects "${PROJECT_NAME}" \
         -ccs.configuration "${BUILD_CONFIG}" \
         -ccs.listErrors 2>&1 | tee "${BUILD_LOG}" || BUILD_FAILED=1
 elif [ -d "/opt/ti/ccs/eclipse" ]; then
     # v11-19 (Eclipse-based, with -ccs.listErrors)
-    "${CCS_ECLIPSE_DIR}/eclipse" -noSplash -data /tmp/workspace \
+    "${CCS_ECLIPSE_DIR}/eclipse" -noSplash -data ${CCS_WORKSPACE} \
         -application com.ti.ccstudio.apps.projectBuild \
         -ccs.projects "${PROJECT_NAME}" \
         -ccs.configuration "${BUILD_CONFIG}" \
         -ccs.listErrors 2>&1 | tee "${BUILD_LOG}" || BUILD_FAILED=1
 else
     # v7-10 (Eclipse-based, without -ccs.listErrors)
-    "${CCS_ECLIPSE_DIR}/eclipse" -noSplash -data /tmp/workspace \
+    "${CCS_ECLIPSE_DIR}/eclipse" -noSplash -data ${CCS_WORKSPACE} \
         -application com.ti.ccstudio.apps.projectBuild \
         -ccs.projects "${PROJECT_NAME}" \
         -ccs.configuration "${BUILD_CONFIG}" \


### PR DESCRIPTION
## 🐛 Fix: Workspace Path Mismatch

Fixes #13

### Problem
Build output files were inaccessible in GitHub Actions because CCS used `/tmp/workspace` for its metadata directory, causing build outputs to be isolated in the Docker container's temporary filesystem instead of the mounted GitHub Actions workspace.

### Root Cause Analysis
The entrypoint.sh script used `/tmp/workspace` in 5 locations:
1. v20+ import command (`-workspace /tmp/workspace`)
2. v7-19 import command (`-data /tmp/workspace`)
3. v20+ build command (`-workspace /tmp/workspace`)
4. v11-19 build command (`-data /tmp/workspace`)
5. v7-10 build command (`-data /tmp/workspace`)

This caused CCS to create build outputs in `/tmp/workspace` which is not accessible from the GitHub Actions workspace mount point (`/github/workspace`).

### Solution
- Changed CCS workspace directory from `/tmp/workspace` to `/github/workspace`
- Added `CCS_WORKSPACE` variable for better maintainability
- Ensures all build outputs and metadata are created in the accessible GitHub Actions workspace
- Applies to all CCS versions (v7 through v20+)

### Changes

#### entrypoint.sh
- Added `CCS_WORKSPACE=/github/workspace` variable after line 211
- Replaced all 5 occurrences of `/tmp/workspace` with `\`

#### .gitignore
- Added `.theia/` (CCS v20+ metadata)
- Added `RemoteSystemsTempFiles/` (Eclipse metadata)

### Impact
✅ **Build outputs (.out files) are now accessible in GitHub Actions**  
✅ **No breaking changes** - project paths remain the same  
✅ **CCS metadata directories are gitignored** - won't pollute repository  
✅ **Applies to ALL CCS versions** when tags are regenerated  

### Testing Plan
After merge, the sync-versions workflow will regenerate all version tags with this fix:
- Test v7.x (old BitRock installer)
- Test v10.x (Eclipse-based)
- Test v12.x (Eclipse-based)
- Test v20.x (Theia-based)

Verify build outputs are accessible using [action-ccstudio-ide-sample](https://github.com/uoohyo/action-ccstudio-ide-sample).

### Related
- Deleted 139 version tags and 48 releases (keeping only `latest`)
- Tags will be regenerated by sync-versions workflow after merge
- All regenerated tags will include this fix