### PR TITLE
Fix CCS v20.0.x patches in action entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -177,6 +177,35 @@ else
 fi
 echo ">>> CCS ${VER} installation complete."
 
+# ============================================
+# Apply patches for CCS v20.0.x bugs (docker-ccstudio-ide#16)
+# ============================================
+if [ "${CCS_VERSION}" = "20.0.0.00012" ] || \
+   [ "${CCS_VERSION}" = "20.0.1.00004" ] || \
+   [ "${CCS_VERSION}" = "20.0.2.00005" ]; then
+    echo ">>> Applying CCS v20.0.x patches..."
+
+    # Backup original script
+    cp "${CCS_ECLIPSE_DIR}/ccs-server-cli.sh" \
+       "${CCS_ECLIPSE_DIR}/ccs-server-cli.sh.orig"
+
+    # Fix 1: POSIX shell syntax (== → =)
+    sed -i 's/ == / = /g' "${CCS_ECLIPSE_DIR}/ccs-server-cli.sh"
+
+    # Fix 2: Create symlink for plugins (fallback for PWD issues)
+    mkdir -p /home
+    ln -sf /opt/ti/ccs/eclipse/plugins /home/plugins
+
+    # Fix 3: Add Node.js to system PATH
+    NODE_PATH=$(find /opt/ti/ccs -name node -type f -executable 2>/dev/null | head -1)
+    if [ -n "$NODE_PATH" ]; then
+        ln -sf "$NODE_PATH" /usr/local/bin/node
+        echo "  Node.js: $($NODE_PATH --version) -> /usr/local/bin/node"
+    fi
+
+    echo ">>> CCS v20.0.x patches applied successfully"
+fi
+
 # Cleanup
 echo ">>> Cleaning up installer files..."
 cd /home


### PR DESCRIPTION
## Summary

Fixes #15 - Adds v20.0.x patches to action-ccstudio-ide/entrypoint.sh to fix critical bugs in `ccs-server-cli.sh`.

## Problem

action-ccstudio-ide performs its own CCS installation (independent of docker-ccstudio-ide), so v20.0.x patches need to be applied here as well.

## Solution

Added the same patch logic from docker-ccstudio-ide#16 to action's entrypoint.sh:

1. **POSIX shell syntax**: Fixed `==` operators to `=`
2. **Plugin paths**: Created symlink fallback
3. **Node.js PATH**: Symlinked Node.js to system PATH

Patches are applied after CCS installation completes, before cleanup.

## Testing

After merge, test with:
- v20.0.0.00012
- v20.0.1.00004
- v20.0.2.00005

Expected: Headless builds should now succeed ✅

## Related

- docker-ccstudio-ide PR #17: https://github.com/uoohyo/docker-ccstudio-ide/pull/17
- docker-ccstudio-ide Issue #16: https://github.com/uoohyo/docker-ccstudio-ide/issues/16